### PR TITLE
BankDivisiCoin: fixed pubkey comparison (.to_string() hack)

### DIFF
--- a/bankdivisicoin.py
+++ b/bankdivisicoin.py
@@ -87,7 +87,7 @@ class Bank:
         # Return tx_outs associated with public_key and not in ^^ list
         return [tx_out for tx in self.txs.values() 
                    for i, tx_out in enumerate(tx.tx_outs)
-                       if public_key == tx_out.public_key
+                       if public_key.to_string() == tx_out.public_key.to_string()
                        and (tx.id, i) not in spent_pairs]
 
     def fetch_balance(self, public_key):


### PR DESCRIPTION
the method `Bank.fetch_utxo()` directly compares the references
between two public keys, rather than their contents; if for
example a deep copy of a previously used public key is passed
on `Bank.fetch_balance()`, the test routine fails, e.g.:
`	assert 10 == bank.fetch_balance(deepcopy(bob_public_key))`