### PR TITLE
PNGCoin: fixed Don't us "!ls | grep" in PNGCoin

### DIFF
--- a/PNGCoin.ipynb
+++ b/PNGCoin.ipynb
@@ -195,8 +195,8 @@
    "source": [
     "import os\n",
     "\n",
-    "def is_file(filename):\n",
-    "    os.path.isfile(filename)\n"
+    "def file_exists(filename):\n",
+    "    return os.path.isfile(filename)\n"
    ]
   },
   {
@@ -205,7 +205,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "is_file(\"coin.pngcoin\")"
+    "file_exists(\"coin.pngcoin\")"
    ]
   },  
   {
@@ -225,7 +225,7 @@
    },
    "outputs": [],
    "source": [
-    "is_file(\"coin.pngcoin\")"
+    "file_exists(\"coin.pngcoin\")"
    ]
   },
   {

--- a/PNGCoin.ipynb
+++ b/PNGCoin.ipynb
@@ -193,9 +193,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!ls | grep \"coin.pngcoin\""
+    "import os\n",
+    "\n",
+    "def is_file(filename):\n",
+    "    os.path.isfile(filename)\n"
    ]
   },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "is_file(\"coin.pngcoin\")"
+   ]
+  },  
   {
    "cell_type": "code",
    "execution_count": null,
@@ -213,7 +225,7 @@
    },
    "outputs": [],
    "source": [
-    "!ls | grep \"coin.pngcoin\""
+    "is_file(\"coin.pngcoin\")"
    ]
   },
   {


### PR DESCRIPTION
Use python standard lib for verifying if the file exists in serialization block.

Fix [https://github.com/superquest/digital-cash/issues/2](url)

